### PR TITLE
Adding NPM Package File and License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2017 Evgeny Poberezkin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "oci-rest-apis-nodejs",
+  "version": "1.0.0",
+  "description": "OCI API SDK for Node",
+  "main": "oci.js",
+  "directories": {
+    "example": "examples"
+  },
+  "dependencies": {
+    "binary-string": "^1.0.0",
+    "deasync": "^0.1.13",
+    "http-signature": "^1.2.0",
+    "jssha": "^2.3.1",
+    "read-chunk": "^3.0.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/christopherbeck/OCI-Rest-APIs-nodejs.git"
+  },
+  "keywords": [
+    "oci",
+    "node",
+    "oracle"
+  ],
+  "author": "Chistopher Beck",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/christopherbeck/OCI-Rest-APIs-nodejs/issues"
+  },
+  "homepage": "https://github.com/christopherbeck/OCI-Rest-APIs-nodejs#readme"
+}


### PR DESCRIPTION
This PR adds a `package.json` file and associated license. This will allow users to run `npm install` to obtain the dependency chain. Eventually, you can add the `node_modules` folder to `.gitignore`, but I left that for backwards compatibility for now.